### PR TITLE
Update Dockerfile to use 1.10-stretch as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM golang:1.10-alpine AS builder
+FROM golang:1.10-stretch AS builder
 
 WORKDIR /go/src/github.com/codeclimate/hestia
 
 ARG DEP_VERSION=v0.4.1
-RUN apk add --update curl git make && \
+RUN apt-get update && \
+    apt-get install curl git make && \
     curl -fsSL -o /usr/local/bin/dep \
     https://github.com/golang/dep/releases/download/$DEP_VERSION/dep-linux-amd64 && \
     chmod +x /usr/local/bin/dep && \

--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/scripts/package
+++ b/scripts/package
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 


### PR DESCRIPTION
The compiled binaries from the alpine image were not compatible with my system nor aws lambda.