### PR TITLE
Use fewer @ mentions in slack responses

### DIFF
--- a/internal/commands/danceparty.go
+++ b/internal/commands/danceparty.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"github.com/codeclimate/hestia/internal/notifiers"
 	"github.com/codeclimate/hestia/internal/types"
 	"math/rand"
@@ -27,7 +26,7 @@ func (c DanceParty) Run() {
 		emojis[i], emojis[j] = emojis[j], emojis[i]
 	})
 
-	message := fmt.Sprintf("<@%s>: %s", c.User, strings.Join(emojis, " "))
+	message := strings.Join(emojis, " ")
 
 	c.Notifier.Log(message)
 }

--- a/internal/commands/echo.go
+++ b/internal/commands/echo.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"github.com/codeclimate/hestia/internal/notifiers"
 	"github.com/codeclimate/hestia/internal/types"
 )
@@ -13,7 +12,7 @@ type Echo struct {
 }
 
 func (c Echo) Run() {
-	message := fmt.Sprintf("<@%s>: %s", c.User, c.Input.Args)
+	message := c.Input.Args
 
 	c.Notifier.Log(message)
 }

--- a/internal/commands/echo_test.go
+++ b/internal/commands/echo_test.go
@@ -22,7 +22,7 @@ func TestRun(t *testing.T) {
 	command.Run()
 
 	messages := notifier.Messages
-	expected := "<@test>: hello"
+	expected := "hello"
 
 	if messages[0] != expected {
 		t.Fatalf("Expected `%s`, but received `%s`", expected, messages[0])

--- a/internal/commands/fallback.go
+++ b/internal/commands/fallback.go
@@ -13,7 +13,7 @@ type Fallback struct {
 }
 
 func (c Fallback) Run() {
-	message := fmt.Sprintf("<@%s> Command `%s` not found", c.User, c.Input.Command)
+	message := fmt.Sprintf("Command `%s` not found", c.User, c.Input.Command)
 
 	c.Notifier.Log(message)
 }

--- a/internal/commands/music.go
+++ b/internal/commands/music.go
@@ -54,7 +54,7 @@ func (c Music) listPlaylists() string {
 func (c Music) getState() string {
 	state := music.GetState()
 
-	return fmt.Sprintf("<@%s>: [%s / %d] %s by %s on %s", c.User, state.Status, state.Volume, state.Title, state.Artist, state.Album)
+	return fmt.Sprintf("[%s / %d] %s by %s on %s", state.Status, state.Volume, state.Title, state.Artist, state.Album)
 }
 
 func (c Music) invokeCommand() string {
@@ -62,7 +62,7 @@ func (c Music) invokeCommand() string {
 	resp := music.InvokeCommand(parts[0], strings.Join(parts[1:], " "))
 
 	if resp.Error != "" {
-		return fmt.Sprintf("<@%s>: %s", c.User, resp.Error)
+		return resp.Error
 	} else {
 		// wait a second for system to react
 		time.Sleep(1 * time.Second)

--- a/internal/commands/nowplaying.go
+++ b/internal/commands/nowplaying.go
@@ -42,9 +42,9 @@ func (c NowPlaying) Run() {
 	var message string
 
 	if len(output) > 0 {
-		message = fmt.Sprintf("<@%s>: now playing\n%s", c.User, strings.Join(output, "\n"))
+		message = strings.Join(output, "\n")
 	} else {
-		message = fmt.Sprintf("<@%s>: all quiet", c.User)
+		message = "all quiet"
 	}
 
 	c.Notifier.Log(message)

--- a/internal/commands/whoami.go
+++ b/internal/commands/whoami.go
@@ -24,7 +24,7 @@ func (c WhoAmI) Run() {
 		log.Fatal(err)
 	}
 
-	message := fmt.Sprintf("<@%s>:\n id: %s\n name: %s\n email: %s", user.ID, user.ID, user.Profile.RealName, user.Profile.Email)
+	message := fmt.Sprintf("\nid: %s\n name: %s\n email: %s", user.ID, user.ID, user.Profile.RealName, user.Profile.Email)
 
 	c.Notifier.Log(message)
 }


### PR DESCRIPTION
These responses can be slimmed down a bit by not including an @ mention.
When responding to a just-invoked command, we don't need to include an @
mention to grab the user's attention.