### PR TITLE
Support variation of help trigger

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -15,25 +15,30 @@ type Command interface {
 func Build(user string, input types.Input, notifier notifiers.Notifier) Command {
 	var command Command
 
-	switch input.Command {
-	case "boom":
-		command = Boom{user, input, notifier}
-	case "danceparty":
-		command = DanceParty{user, input, notifier}
-	case "echo":
-		command = Echo{user, input, notifier}
-	case "help":
+	if input.Args == "help" {
+		input := types.Input{Args: input.Command}
 		command = Help{user, input, notifier}
-	case "nowplaying":
-		command = NowPlaying{user, input, notifier}
-	case "music":
-		command = Music{user, input, notifier}
-	case "weather":
-		command = Weather{user, input, notifier}
-	case "whoami":
-		command = WhoAmI{user, input, notifier}
-	default:
-		command = Fallback{user, input, notifier}
+	} else {
+		switch input.Command {
+		case "boom":
+			command = Boom{user, input, notifier}
+		case "danceparty":
+			command = DanceParty{user, input, notifier}
+		case "echo":
+			command = Echo{user, input, notifier}
+		case "help":
+			command = Help{user, input, notifier}
+		case "nowplaying":
+			command = NowPlaying{user, input, notifier}
+		case "music":
+			command = Music{user, input, notifier}
+		case "weather":
+			command = Weather{user, input, notifier}
+		case "whoami":
+			command = WhoAmI{user, input, notifier}
+		default:
+			command = Fallback{user, input, notifier}
+		}
 	}
 
 	return command


### PR DESCRIPTION
In addition to `help <command>`, also support `<command> help`.