### PR TITLE
Fix some format strings

### DIFF
--- a/internal/commands/fallback.go
+++ b/internal/commands/fallback.go
@@ -13,7 +13,7 @@ type Fallback struct {
 }
 
 func (c Fallback) Run() {
-	message := fmt.Sprintf("Command `%s` not found", c.User, c.Input.Command)
+	message := fmt.Sprintf("Command `%s` not found", c.Input.Command)
 
 	c.Notifier.Log(message)
 }

--- a/internal/commands/music.go
+++ b/internal/commands/music.go
@@ -42,13 +42,13 @@ func (c Music) info() string {
 	lines = append(lines, fmt.Sprintf("  username: %s", config.Fetch("music_username")))
 	lines = append(lines, fmt.Sprintf("apps: <%s|ios>, <%s|android>", app_store_url, play_store_url))
 
-	return fmt.Sprintf("<@%s>:\n%s", c.User, strings.Join(lines, "\n"))
+	return strings.Join(lines, "\n")
 }
 
 func (c Music) listPlaylists() string {
 	playlists := music.ListPlaylists()
 
-	return fmt.Sprintf("<@%s>:\n%s", c.User, strings.Join(playlists, "\n"))
+	return strings.Join(playlists, "\n")
 }
 
 func (c Music) getState() string {


### PR DESCRIPTION
The fallback command used a format string with one placeholder and two
arguments, which resulted in some weird output.