### PR TITLE
Update slack event mapping

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -11,7 +11,7 @@ type Event struct {
 	Text           string `json:"text"`
 	Timestamp      string `json:"ts"`
 	Channel        string `json:"channel"`
-	EventTimestamp string `json:"event_ts"`
+	EventTimestamp int    `json:"event_ts"`
 }
 
 type EventCallback struct {


### PR DESCRIPTION
The `event_ts` field changed from a string to a number at some point.