### PR TITLE
Update slack event mapping

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -11,7 +11,7 @@ type Event struct {
 	Text           string `json:"text"`
 	Timestamp      string `json:"ts"`
 	Channel        string `json:"channel"`
-	EventTimestamp int    `json:"event_ts"`
+	EventTimestamp string `json:"event_ts"`
 }
 
 type EventCallback struct {


### PR DESCRIPTION
Looks like `event_ts` switched from an int to string type recently.