### PR TITLE
Update to git `2.11.0-3+deb9u3`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.10-stretch AS builder
 WORKDIR /go/src/github.com/codeclimate/hestia
 
 ARG DEP_VERSION=v0.4.1
+COPY dockerfile-version /etc/dockerfile-version
 RUN apt-get update && \
     apt-get install -y curl git make && \
     curl -fsSL -o /usr/local/bin/dep \

--- a/dockerfile-version
+++ b/dockerfile-version
@@ -1,0 +1,4 @@
+# Edit this file to bust the build cache ahead of the apt-get layer. This can be
+# used to update the packages installed into the image when (for example) a
+# vulnerability is patched in openssl.
+1


### PR DESCRIPTION
According to the Debian security announcement, the jessie git package 2.11.0-3+deb9u3 has been patched with fixes for the submodule exploit.

make image with this revision of the repo results in an image with that version installed.

1: https://www.debian.org/security/2018/dsa-4212